### PR TITLE
Support TinyTranslations 4.1.1

### DIFF
--- a/dependency-reduced-pom.xml
+++ b/dependency-reduced-pom.xml
@@ -33,13 +33,13 @@
             <configuration>
               <artifactSet>
                 <includes>
-                  <include>de.cubbossa:Translations</include>
+                  <include>de.cubbossa:TinyTranslations</include>
                 </includes>
               </artifactSet>
               <relocations>
                 <relocation>
-                  <pattern>de.cubbossa.translations</pattern>
-                  <shadedPattern>me.xidentified.devotions.libs.translations</shadedPattern>
+                  <pattern>de.cubbossa.tinytranslations</pattern>
+                  <shadedPattern>me.xidentified.devotions.libs.tinytranslations</shadedPattern>
                 </relocation>
               </relocations>
             </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -40,13 +40,13 @@
                         <configuration>
                             <artifactSet>
                                 <includes>
-                                    <include>de.cubbossa:Translations</include>
+                                    <include>de.cubbossa:TinyTranslations</include>
                                 </includes>
                             </artifactSet>
                             <relocations>
                                 <relocation>
-                                    <pattern>de.cubbossa.translations</pattern>
-                                    <shadedPattern>me.xidentified.devotions.libs.translations</shadedPattern>
+                                    <pattern>de.cubbossa.tinytranslations</pattern>
+                                    <shadedPattern>me.xidentified.devotions.libs.tinytranslations</shadedPattern>
                                 </relocation>
                             </relocations>
                         </configuration>
@@ -84,8 +84,8 @@
     <dependencies>
         <dependency>
             <groupId>de.cubbossa</groupId>
-            <artifactId>Translations</artifactId>
-            <version>3.2.3</version>
+            <artifactId>TinyTranslations</artifactId>
+            <version>4.1.1</version>
         </dependency>
         <dependency>
             <groupId>io.papermc.paper</groupId>

--- a/src/main/java/me/xidentified/devotions/Miracle.java
+++ b/src/main/java/me/xidentified/devotions/Miracle.java
@@ -1,6 +1,6 @@
 package me.xidentified.devotions;
 
-import de.cubbossa.translations.Message;
+import de.cubbossa.tinytranslations.Message;
 import me.xidentified.devotions.util.Messages;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;

--- a/src/main/java/me/xidentified/devotions/commandexecutors/DeityCommand.java
+++ b/src/main/java/me/xidentified/devotions/commandexecutors/DeityCommand.java
@@ -1,5 +1,6 @@
 package me.xidentified.devotions.commandexecutors;
 
+import de.cubbossa.tinytranslations.GlobalMessages;
 import me.xidentified.devotions.Deity;
 import me.xidentified.devotions.Devotions;
 import me.xidentified.devotions.managers.FavorManager;
@@ -26,7 +27,7 @@ public class DeityCommand implements CommandExecutor, TabCompleter {
     @Override
     public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, String[] args) {
         if (!(sender instanceof Player player)) {
-            Devotions.getInstance().sendMessage(sender, Messages.GENERAL_CMD_PLAYER_ONLY);
+            Devotions.getInstance().sendMessage(sender, GlobalMessages.CMD_PLAYER_ONLY);
             return true;
         }
 

--- a/src/main/java/me/xidentified/devotions/commandexecutors/DevotionsCommandExecutor.java
+++ b/src/main/java/me/xidentified/devotions/commandexecutors/DevotionsCommandExecutor.java
@@ -1,5 +1,6 @@
 package me.xidentified.devotions.commandexecutors;
 
+import de.cubbossa.tinytranslations.GlobalMessages;
 import me.xidentified.devotions.Devotions;
 import me.xidentified.devotions.util.Messages;
 import org.bukkit.ChatColor;
@@ -35,7 +36,7 @@ public class DevotionsCommandExecutor implements CommandExecutor, TabCompleter {
 
         if ("reload".equalsIgnoreCase(args[0])) {
             if (!sender.hasPermission("devotions.reload")) {
-                plugin.sendMessage(sender, Messages.GENERAL_CMD_NO_PERM);
+                plugin.sendMessage(sender, GlobalMessages.NO_PERM_CMD);
                 return true;
             }
 
@@ -45,12 +46,12 @@ public class DevotionsCommandExecutor implements CommandExecutor, TabCompleter {
         }
         if ("saveitem".equalsIgnoreCase(args[0])) {
             if (!sender.hasPermission("devotions.admin")) {
-                plugin.sendMessage(sender, Messages.GENERAL_CMD_NO_PERM);
+                plugin.sendMessage(sender, GlobalMessages.NO_PERM_CMD);
                 return true;
             }
 
             if (!(sender instanceof Player player)) {
-                sender.sendMessage("This command can only be used by players.");
+                plugin.sendMessage(sender, GlobalMessages.CMD_PLAYER_ONLY);
                 return true;
             }
 

--- a/src/main/java/me/xidentified/devotions/commandexecutors/FavorCommand.java
+++ b/src/main/java/me/xidentified/devotions/commandexecutors/FavorCommand.java
@@ -1,10 +1,14 @@
 package me.xidentified.devotions.commandexecutors;
 
+import de.cubbossa.tinytranslations.GlobalMessages;
 import me.xidentified.devotions.Devotions;
 import me.xidentified.devotions.managers.FavorManager;
 import me.xidentified.devotions.util.FavorUtils;
 import me.xidentified.devotions.util.Messages;
+import net.kyori.adventure.text.format.TextColor;
+import net.kyori.adventure.text.minimessage.tag.Tag;
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
+import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 import org.bukkit.Bukkit;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
@@ -35,7 +39,7 @@ public class FavorCommand implements CommandExecutor, TabCompleter {
             plugin.sendMessage(player, Messages.FAVOR_CURRENT.formatted(
                     Placeholder.unparsed("deity", deityName),
                     Placeholder.unparsed("favor", String.valueOf(favorManager.getFavor())),
-                    Placeholder.parsed("color", FavorUtils.getColorForFavor(favorManager.getFavor()))
+                    TagResolver.resolver("favor_col", Tag.styling(s -> s.color(FavorUtils.getColorForFavor(favorManager.getFavor()))))
             ));
             return true;
         }
@@ -47,7 +51,7 @@ public class FavorCommand implements CommandExecutor, TabCompleter {
 
         // Check for permission
         else if (!player.hasPermission("devotions.admin")) {
-            plugin.sendMessage(player, Messages.GENERAL_CMD_NO_PERM);
+            plugin.sendMessage(player, GlobalMessages.NO_PERM_CMD);
             return true;
         }
 
@@ -89,7 +93,7 @@ public class FavorCommand implements CommandExecutor, TabCompleter {
         plugin.sendMessage(player, Messages.FAVOR_SET_TO.formatted(
                 Placeholder.unparsed("deity", favorManager.getDeity().getName()),
                 Placeholder.unparsed("favor", String.valueOf(favorManager.getFavor())),
-                Placeholder.parsed("color", FavorUtils.getColorForFavor(favorManager.getFavor()))
+                TagResolver.resolver("favor_col", Tag.styling(s -> s.color(FavorUtils.getColorForFavor(favorManager.getFavor()))))
         ));
         return true;
     }

--- a/src/main/java/me/xidentified/devotions/commandexecutors/RitualCommand.java
+++ b/src/main/java/me/xidentified/devotions/commandexecutors/RitualCommand.java
@@ -1,5 +1,6 @@
 package me.xidentified.devotions.commandexecutors;
 
+import de.cubbossa.tinytranslations.GlobalMessages;
 import me.xidentified.devotions.Devotions;
 import me.xidentified.devotions.rituals.Ritual;
 import me.xidentified.devotions.util.Messages;
@@ -26,7 +27,7 @@ public class RitualCommand implements CommandExecutor, TabCompleter {
     @Override
     public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, String[] args) {
         if (!(sender instanceof Player player)) {
-            Devotions.getInstance().sendMessage(sender, Messages.GENERAL_CMD_PLAYER_ONLY);
+            Devotions.getInstance().sendMessage(sender, GlobalMessages.CMD_PLAYER_ONLY);
             return true;
         }
 

--- a/src/main/java/me/xidentified/devotions/commandexecutors/ShrineCommandExecutor.java
+++ b/src/main/java/me/xidentified/devotions/commandexecutors/ShrineCommandExecutor.java
@@ -1,5 +1,6 @@
 package me.xidentified.devotions.commandexecutors;
 
+import de.cubbossa.tinytranslations.GlobalMessages;
 import me.xidentified.devotions.Deity;
 import me.xidentified.devotions.Devotions;
 import me.xidentified.devotions.Shrine;
@@ -40,7 +41,7 @@ public class ShrineCommandExecutor implements CommandExecutor, Listener, TabComp
     @Override
     public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, String[] args) {
         if (!(sender instanceof Player player)) {
-            Devotions.getInstance().sendMessage(sender, Messages.GENERAL_CMD_PLAYER_ONLY);
+            Devotions.getInstance().sendMessage(sender, GlobalMessages.CMD_PLAYER_ONLY);
             return true;
         }
 

--- a/src/main/java/me/xidentified/devotions/managers/FavorManager.java
+++ b/src/main/java/me/xidentified/devotions/managers/FavorManager.java
@@ -7,7 +7,10 @@ import me.xidentified.devotions.Devotions;
 import me.xidentified.devotions.storage.DevotionStorage;
 import me.xidentified.devotions.util.FavorUtils;
 import me.xidentified.devotions.util.Messages;
+import net.kyori.adventure.text.format.TextColor;
+import net.kyori.adventure.text.minimessage.tag.Tag;
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
+import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 
@@ -127,7 +130,7 @@ public class FavorManager {
             plugin.sendMessage(player, Messages.FAVOR_INCREASED.formatted(
                     Placeholder.unparsed("deity", deity.getName()),
                     Placeholder.unparsed("favor", String.valueOf(this.favor)),
-                    Placeholder.parsed("color", FavorUtils.getColorForFavor(this.favor))
+                    TagResolver.resolver("favor_col", Tag.styling(s -> s.color(FavorUtils.getColorForFavor(this.favor))))
             ));
 
             // Save the player's devotion data
@@ -157,7 +160,7 @@ public class FavorManager {
             plugin.sendMessage(player, Messages.FAVOR_DECREASED.formatted(
                     Placeholder.unparsed("deity", deity.getName()),
                     Placeholder.unparsed("favor", String.valueOf(this.favor)),
-                    Placeholder.parsed("color", FavorUtils.getColorForFavor(this.favor))
+                    TagResolver.resolver("favor_col", Tag.styling(s -> s.color(FavorUtils.getColorForFavor(this.favor))))
             ));
         }
 

--- a/src/main/java/me/xidentified/devotions/util/FavorUtils.java
+++ b/src/main/java/me/xidentified/devotions/util/FavorUtils.java
@@ -1,23 +1,25 @@
 package me.xidentified.devotions.util;
 
 import me.xidentified.devotions.Devotions;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextColor;
 
 public class FavorUtils {
 
-    public static String getColorForFavor(int favor) {
+    public static TextColor getColorForFavor(int favor) {
         Devotions plugin = Devotions.getInstance();
         int curseThreshold = plugin.getConfig().getInt("curse-threshold");
         int blessingThreshold = plugin.getConfig().getInt("blessing-threshold");
         int miracleThreshold = plugin.getConfig().getInt("miracle-threshold");
 
         if (favor <= curseThreshold) {
-            return "<red>";
+            return NamedTextColor.RED;
         } else if (favor <= blessingThreshold) {
-            return "<yellow>";
+            return NamedTextColor.YELLOW;
         } else if (favor <= miracleThreshold) {
-            return "<green>";
+            return NamedTextColor.GREEN;
         } else {
-            return "<aqua>";
+            return NamedTextColor.AQUA;
         }
     }
 }

--- a/src/main/java/me/xidentified/devotions/util/Messages.java
+++ b/src/main/java/me/xidentified/devotions/util/Messages.java
@@ -1,249 +1,244 @@
 package me.xidentified.devotions.util;
 
-import de.cubbossa.translations.Message;
-import de.cubbossa.translations.MessageBuilder;
+import de.cubbossa.tinytranslations.GlobalStyles;
+import de.cubbossa.tinytranslations.Message;
+import de.cubbossa.tinytranslations.MessageBuilder;
 
 public class Messages {
 
-	public static final Message GENERAL_CMD_PLAYER_ONLY = new MessageBuilder("general.must_be_player")
-			.withDefault("<negative>Only players can use this command.")
-			.build();
-	public static final Message GENERAL_NO_PERM = new MessageBuilder("general.no_perm")
-			.withDefault("<negative>You don't have sufficient permission")
-			.build();
-	public static final Message GENERAL_CMD_NO_PERM = new MessageBuilder("general.cmd.no_perm")
-			.withDefault("<negative>You don't have permission to use this command.")
-			.build();
 	public static final Message GENERAL_PLAYER_NOT_FOUND = new MessageBuilder("general.player_not_found")
-			.withDefault("<negative>Player not found: <name>")
+			.withDefault("<prefix_negative>Player not found: {name}")
 			.build();
 	public static final Message DEVOTION_RELOAD_SUCCESS = new MessageBuilder("devotion.reload_success")
-			.withDefault("<positive>Devotions successfully reloaded!")
+			.withDefault("<prefix>Devotions successfully reloaded!")
 			.build();
 	public static final Message DEVOTION_SET = new MessageBuilder("devotion.set")
-			.withDefault("<positive>You are now devoted to <name>. Your favor is <favor>.")
+			.withDefault("<prefix>You are now devoted to {name}. Your favor is {favor}.")
 			.withPlaceholder("name", "favor")
 			.build();
 	public static final Message DEITY_NOT_FOUND = new MessageBuilder("deity.not_found")
-			.withDefault("<negative>Unknown deity. Please choose a valid deity name.")
+			.withDefault("<prefix_negative>Unknown deity. Please choose a valid deity name.")
 			.build();
 	public static final Message DEITY_NO_DEITY_FOUND = new MessageBuilder("deity.no_deity_found")
-			.withDefault("<negative>No deities found.")
+			.withDefault("<prefix_negative>No deities found.")
 			.build();
 	public static final Message DEITY_BLESSED = new MessageBuilder("deity.blessed")
-			.withDefault("<positive><deity> has blessed you with <blessing>!")
+			.withDefault("<prefix>{deity} has blessed you with {blessing}!")
 			.withPlaceholders("deity", "blessing")
 			.build();
 	public static final Message DEITY_CURSED = new MessageBuilder("deity.cursed")
-			.withDefault("<positive><deity> has cursed you with <curse>!")
+			.withDefault("<prefix>{deity} has cursed you with {curse}!")
 			.withPlaceholders("deity", "curse")
 			.build();
 	public static final Message DEITY_CMD_USAGE = new MessageBuilder("deity.cmd.usage")
-			.withDefault("<yellow>Usage: /deity <select|info> [DeityName]")
+			.withDefault("<offset>Usage: <cmd_syntax>/deity <arg>select|info</arg> <arg_opt>DeityName</arg_opt></cmd_syntax>")
 			.build();
 	public static final Message DEITY_CMD_SPECIFY_DEITY = new MessageBuilder("deity.cmd.specify_deity")
-			.withDefault("<yellow>Please specify the deity you wish to worship.")
+			.withDefault("<prefix_warning>Please specify the deity you wish to worship.")
 			.build();
 	public static final Message DEITY_SPECIFY_PLAYER = new MessageBuilder("deity.cmd.specify_player")
-			.withDefault("<warning>Please specify the deity whose information you wish to view.")
+			.withDefault("<prefix_warning>Please specify the deity whose information you wish to view.")
 			.build();
 	public static final Message DEITY_LIST_HEADER = new MessageBuilder("deity.list.header")
-			.withDefault("<gold>Available Deities:")
+			.withDefault("<primary>Available Deities:")
 			.build();
 	public static final Message DEITY_LIST_ENTRY = new MessageBuilder("deity.list.entry")
-			.withDefault("<gray>- <name></gray>")
+			.withDefault("<text>- {name}</text>")
 			.withPlaceholder("name")
 			.build();
 	public static final Message DEITY_INFO = new MessageBuilder("deity.info")
 			.withDefault("""
-					<gold>Details of <name>
-					<yellow>Lore: <gray><lore>
-					<yellow>Domain: <gray><domain>
-					<yellow>Alignment: <gray><alignment>
-					<yellow>Favored Rituals: <gray><rituals>
-					<yellow>Favored Offerings: <gray><offerings>""")
+					<primary>Details of {name}
+					<offset>Lore: <text>{lore}
+					<offset>Domain: <text>{domain}
+					<offset>Alignment: <text>{alignment}
+					<offset>Favored Rituals: <text>{rituals}
+					<offset>Favored Offerings: <text>{offerings}""")
 			.withPlaceholders("name", "lore", "domain", "alignment", "rituals", "offerings")
 			.build();
 
 	public static final Message MEDITATION_COMPLETE = new MessageBuilder("meditation.complete")
-			.withDefault("<positive>Meditation complete! You can now move.")
+			.withDefault("<prefix>Meditation complete! You can now move.")
 			.build();
 	public static final Message MEDIDATION_CANCELLED = new MessageBuilder("meditation.cancelled")
-			.withDefault("<negative>You moved during meditation! Restarting timer...")
+			.withDefault("<prefix_negative>You moved during meditation! Restarting timer...")
 			.build();
 
 	public static final Message SHRINE_NO_PERM_LIST = new MessageBuilder("shrines.list.no_perm")
-			.withDefault("<negative>You don't have permission to list shrines.")
+			.withDefault("<prefix_negative>You don't have permission to list shrines.")
 			.build();
 	public static final Message SHRINE_NO_DESIGNATED_SHRINE = new MessageBuilder("shrines.list.no_shrines")
-			.withDefault("<negative>There are no designated shrines.")
+			.withDefault("<prefix_negative>There are no designated shrines.")
 			.build();
 	public static final Message SHRINE_LIST = new MessageBuilder("shrines.list.header")
-			.withDefault("<yellow>Shrines:")
+			.withDefault("<offset>Shrines:")
 			.build();
 	public static final Message SHRINE_INFO = new MessageBuilder("shrines.list.shrine")
-			.withDefault("<hover:show_text:Click to teleport><click:run_command:'/teleport @p <x> <y> <z>'><deity> at <x:#.#>, <y:#.#>, <z:#.#>")
+			.withDefault("<hover:show_text:Click to teleport><click:run_command:/teleport @p {x} {y} {z}>{deity} at {x:#.#}, {y:#.#}, {z:#.#}")
 			.withPlaceholders("deity", "x", "y", "z")
 			.build();
 	public static final Message SHRINE_NO_PERM_REMOVE = new MessageBuilder("shrines.remove.no_perm")
-			.withDefault("<negative>You don't have permission to remove shrines.")
+			.withDefault("<prefix_negative>You don't have permission to remove shrines.")
 			.build();
 	public static final Message SHRINE_NO_PERM_SET = new MessageBuilder("shrines.set.no_perm")
-			.withDefault("<negative>You don't have permission to set a shrine.")
+			.withDefault("<prefix_negative>You don't have permission to set a shrine.")
 			.build();
 	public static final Message SHRINE_RC_TO_REMOVE = new MessageBuilder("shrines.right_click_to_remove")
-			.withDefault("<warning>Right-click on a shrine to remove it.")
+			.withDefault("<prefix_warning>Right-click on a shrine to remove it.")
 			.build();
 	public static final Message SHRINE_LIMIT_REACHED = new MessageBuilder("shrines.limit_reached")
-			.withDefault("<negative>You have reached the maximum number of shrines (<limit>).")
+			.withDefault("<prefix_negative>You have reached the maximum number of shrines ({limit}).")
 			.withPlaceholder("limit")
 			.build();
 	public static final Message SHRINE_FOLLOW_DEITY_TO_DESIGNATE = new MessageBuilder("shrines.follow_deity_to_designate")
-			.withDefault("<negative>You need to follow a deity to designate a shrine!")
+			.withDefault("<prefix_negative>You need to follow a deity to designate a shrine!")
 			.build();
 	public static final Message SHRINE_NOT_FOLLOWING_DEITY = new MessageBuilder("shrines.not_following_deity")
-			.withDefault("<negative>Only followers of <deity> may use this shrine.")
+			.withDefault("<prefix_negative>Only followers of {deity} may use this shrine.")
 			.withPlaceholder("deity")
 			.build();
 	public static final Message SHRINE_COOLDOWN = new MessageBuilder("shrines.cooldown")
-			.withDefault("<negative>You must wait <cooldown:'m'>m <cooldown:'s'>s before performing another ritual.")
+			.withDefault("<prefix_negative>You must wait {cooldown:'m'}m {cooldown:'s'}s before performing another ritual.")
 			.build();
 	public static final Message SHRINE_ALREADY_EXISTS = new MessageBuilder("shrines.cooldown")
-			.withDefault("<negative>A shrine already exists at this location!")
+			.withDefault("<prefix_negative>A shrine already exists at this location!")
 			.build();
 	public static final Message SHRINE_CLICK_BLOCK_TO_DESIGNATE = new MessageBuilder("shrines.click_block_to_create")
-			.withDefault("<warning>Right-click on a block to designate it as a shrine for <deity>")
+			.withDefault("<prefix_warning>Right-click on a block to designate it as a shrine for {deity}")
 			.withPlaceholder("deity")
 			.build();
 	public static final Message SHRINE_SUCCESS = new MessageBuilder("shrines.shrine_created")
-			.withDefault("<positive>Successfully designated a shrine for <deity>!")
+			.withDefault("<prefix>Successfully designated a shrine for {deity}!")
 			.withPlaceholder("deity")
 			.build();
 	public static final Message SHRINE_DEITY_NOT_FOUND = new MessageBuilder("shrines.deity_not_found")
-			.withDefault("<negative>Could not determine your deity, please inform an admin.")
+			.withDefault("<prefix_negative>Could not determine your deity, please inform an admin.")
 			.build();
 	public static final Message SHRINE_REMOVED = new MessageBuilder("shrines.remove.success")
-			.withDefault("<positive>Shrine removed successfully!")
+			.withDefault("<prefix>Shrine removed successfully!")
 			.build();
 	public static final Message SHRINE_REMOVE_FAIL = new MessageBuilder("shrines.remove.not_found")
-			.withDefault("<negative>Failed to remove shrine. You might not own it.")
+			.withDefault("<prefix_negative>Failed to remove shrine. You might not own it.")
 			.build();
 	public static final Message SHRINE_REMOVE_NOT_FOUND = new MessageBuilder("shrines.remove.not_found")
-			.withDefault("<negative>No shrine found at this location.")
+			.withDefault("<prefix_negative>No shrine found at this location.")
 			.build();
 	public static final Message SHRINE_OFFERING_ACCEPTED = new MessageBuilder("shrines.offering_accepted")
-			.withDefault("<positive>Your offering has been accepted!")
+			.withDefault("<prefix>Your offering has been accepted!")
 			.build();
 	public static final Message SHRINE_PLACE_ON_TOP = new MessageBuilder("shrines.cannot_place_on_top")
-			.withDefault("<negative>You cannot place blocks on top of a shrine!")
+			.withDefault("<prefix_negative>You cannot place blocks on top of a shrine!")
 			.build();
 	public static final Message SHRINE_CANNOT_BREAK = new MessageBuilder("shrines.cannot_break_shrines")
-			.withDefault("<negative>You cannot destroy shrines! Remove with <warning>/shrine remove</warning>.")
+			.withDefault("<prefix_negative>You cannot destroy shrines! Remove with <cmd_syntax>/shrine remove</cmd_syntax>.")
 			.build();
 	public static final Message SHRINE_OFFERING_DECLINED = new MessageBuilder("shrines.offering_declined")
-			.withDefault("<negative>Your offering was not accepted by <subject>.")
+			.withDefault("<prefix_negative>Your offering was not accepted by {subject}.")
 			.withPlaceholder("subject")
 			.build();
 
 	public static final Message FAVOR_CMD_USAGE = new MessageBuilder("favor.cmd.usage")
-			.withDefault("<warning>Usage: /favor <set|give|take> <playername> <amount>")
+			.withDefault("<prefix_warning>Usage: <cmd_syntax>/favor <arg>set|give|take</arg> <arg>playername</arg> <arg>amount</arg></cmd_syntax>")
 			.build();
 	public static final Message FAVOR_CMD_PLAYER_DOESNT_WORSHIP = new MessageBuilder("favor.cmd.player_does_not_worship")
-			.withDefault("<negative><player> doesn't worship any deity.")
+			.withDefault("<prefix_negative>{player} doesn't worship any deity.")
 			.withPlaceholder("player")
 			.build();
 	public static final Message FAVOR_CMD_INVALID_ACTION = new MessageBuilder("favor.cmd.invalid_action")
-			.withDefault("<negative>Invalid action. Use set, give, or take.")
+			.withDefault("<prefix_negative>Invalid action. Use set, give, or take.")
 			.build();
 	public static final Message FAVOR_CMD_NUMBER_FORMAT = new MessageBuilder("favor.cmd.invalid_number_format")
-			.withDefault("<negative>Invalid amount. Please enter a number.")
+			.withDefault("<prefix_negative>Invalid amount. Please enter a number.")
 			.build();
 	public static final Message FAVOR_CURRENT = new MessageBuilder("favor.amount.current_favor")
-			.withDefault("<yellow>Your current favor with <deity> is <color><favor>")
+			.withDefault("<offset>Your current favor with {deity} is <favor_col>{favor}")
 			.withPlaceholder("deity")
 			.withPlaceholder("favor")
+			.withPlaceholder("favor_col")
 			.build();
 	public static final Message FAVOR_NO_DEVOTION_SET = new MessageBuilder("favor.cmd.no_devotion_set")
-			.withDefault("<negative>You don't have any devotion set.")
+			.withDefault("<prefix_negative>You don't have any devotion set.")
 			.build();
 	public static final Message FAVOR_SET_TO = new MessageBuilder("favor.amount.set_to")
-			.withDefault("<yellow>Your favor has been set to <color><favor>")
+			.withDefault("<offset>Your favor has been set to <favor_col>{favor}")
+			.withPlaceholders("favor", "favor_col")
 			.build();
 	public static final Message FAVOR_INCREASED = new MessageBuilder("favor.amount.favor_increased")
-			.withDefault("<positive>Your favor with <deity> has increased to <color><favor>")
+			.withDefault("<prefix>Your favor with {deity} has increased to <favor_col>{favor}")
 			.build();
 	public static final Message FAVOR_DECREASED = new MessageBuilder("favor.amount.favor_decreased")
-			.withDefault("<negative>Your favor with <deity> has decreased to <color><favor>")
+			.withDefault("<prefix_negative>Your favor with {deity} has decreased to <favor_col>{favor}")
+			.withPlaceholders("favor", "favor_col", "deity")
 			.build();
 	public static final Message RITUAL_CMD_USAGE = new MessageBuilder("ritual.cmd.usage")
-			.withDefault("<warning>Usage: /ritual <info> [RitualName]")
+			.withDefault("<prefix_warning>Usage: <cmd_syntax>/ritual <arg>info</arg> <arg_opt>RitualName</arg_opt></cmd_syntax>")
 			.build();
 	public static final Message RITUAL_CMD_SPECIFY = new MessageBuilder("ritual.cmd.specify_ritual")
-			.withDefault("<yellow>Please specify the ritual you'd like to lookup information for.")
+			.withDefault("<offset>Please specify the ritual you'd like to lookup information for.")
 			.build();
 	public static final Message RITUAL_INFO = new MessageBuilder("ritual.info")
 			.withDefault("""
-					<gold>Details of <display-name>
-					<yellow>Description: <gray><description>
-					<yellow>Key Item: <gray><item-name>
-					<yellow>Favor Rewarded: <gray><favour-amount>""")
+					<primary>Details of {display-name}
+					<offset>Description: <text>{description}
+					<offset>Key Item: <text>{item-name}
+					<offset>Favor Rewarded: <text>{favour-amount}""")
 			.withPlaceholders("display-name", "description", "item-name", "favour-amount")
 			.build();
 	public static final Message RITUAL_NOT_FOUND = new MessageBuilder("ritual.not_found")
-			.withDefault("<negative>Unknown ritual. Please choose a valid ritual name.")
+			.withDefault("<prefix_negative>Unknown ritual. Please choose a valid ritual name.")
 			.build();
 	public static final Message RITUAL_START = new MessageBuilder("ritual.start")
-			.withDefault("<light_purple>The <ritual> has begun...")
+			.withDefault("<accent>The {ritual} has begun...")
 			.withPlaceholder("ritual")
 			.build();
 	public static final Message RITUAL_FAILURE = new MessageBuilder("ritual.failure")
-			.withDefault("<positive><ritual> was a success! Blessings upon ye!")
+			.withDefault("<prefix>{ritual} was a success! Blessings upon ye!")
 			.withPlaceholder("ritual")
 			.build();
 	public static final Message RITUAL_SUCCESS = new MessageBuilder("ritual.success")
-			.withDefault("<negative><ritual> has failed - the conditions were not met!")
+			.withDefault("<prefix_negative>{ritual} has failed - the conditions were not met!")
 			.withPlaceholder("ritual")
 			.build();
 	public static final Message RITUAL_RETURN_TO_RESUME = new MessageBuilder("ritual.return_to_resume")
-			.withDefault("<light_purple>Return to the shrine to complete the ritual.")
+			.withDefault("<accent>Return to the shrine to complete the ritual.")
 			.build();
 
 	public static final Message MIRACLE_CMD_USAGE = new MessageBuilder("miracle.cmd.usage")
-			.withDefault("<warning>Usage: /testmiracle <number>")
+			.withDefault("<prefix_warning>Usage: <cmd_syntax>/testmiracle <arg>number</arg></cmd_syntax>")
 			.build();
 	public static final Message MIRACLE_CMD_NO_MIRACLES = new MessageBuilder("miracle.cmd.no_miracles")
-			.withDefault("<negative>No miracles are loaded.")
+			.withDefault("<prefix_negative>No miracles are loaded.")
 			.build();
 	public static final Message MIRACLE_CMD_AVAILABLE = new MessageBuilder("miracles.cmd.list_available")
-			.withDefault("<positive>Available miracles: <yellow><miracles>")
+			.withDefault("<prefix>Available miracles: <offset>{miracles}")
 			.withPlaceholder("miracles")
 			.build();
 	public static final Message MIRACLE_CMD_UNKNOWN_MIRACLE = new MessageBuilder("miracle.cmd.unknown_miracle")
-			.withDefault("<negative>Unknown miracle")
+			.withDefault("<prefix_negative>Unknown miracle")
 			.withPlaceholder("miracle")
 			.build();
 	public static final Message MIRACLE_BESTOWED = new MessageBuilder("miracle.bestowed")
-			.withDefault("<positive>A miracle has been bestowed upon ye!")
+			.withDefault("<prefix>A miracle has been bestowed upon ye!")
 			.build();
 	public static final Message MIRACLE_SAVED_FROM_DEATH = new MessageBuilder("miracle.saved_from_death")
-			.withDefault("<positive>A miracle has revived you upon death!")
+			.withDefault("<prefix>A miracle has revived you upon death!")
 			.build();
 	public static final Message MIRACLE_HERO_OF_VILLAGE = new MessageBuilder("miracle.hero_of_the_village")
-			.withDefault("<positive>A miracle has granted you the Hero of the Village effect!")
+			.withDefault("<prefix>A miracle has granted you the Hero of the Village effect!")
 			.build();
 	public static final Message MIRACLE_FIRE_RESISTANCE = new MessageBuilder("miracle.fire_resistance")
-			.withDefault("<positive>A miracle has granted you Fire Resistance!")
+			.withDefault("<prefix>A miracle has granted you Fire Resistance!")
 			.build();
 	public static final Message MIRACLE_REPAIR = new MessageBuilder("miracle.repair")
-			.withDefault("<positive>A miracle has repaired all your items!")
+			.withDefault("<prefix>A miracle has repaired all your items!")
 			.build();
 	public static final Message MIRACLE_HARVEST = new MessageBuilder("miracle.harvest")
-			.withDefault("<positive>A miracle has blessed you with a bountiful harvest!")
+			.withDefault("<prefix>A miracle has blessed you with a bountiful harvest!")
 			.build();
 	public static final Message MIRACLE_GOLEM = new MessageBuilder("miracle.iron_golem")
-			.withDefault("<positive>A miracle has summoned Iron Golems to aid you!")
+			.withDefault("<prefix>A miracle has summoned Iron Golems to aid you!")
 			.build();
 	public static final Message MIRACLE_WOLVES = new MessageBuilder("miracle.wolves")
-			.withDefault("<positive>A miracle has summoned friendly Wolves to protect you!")
+			.withDefault("<prefix>A miracle has summoned friendly Wolves to protect you!")
 			.build();
 }

--- a/src/main/resources/lang/de.yml
+++ b/src/main/resources/lang/de.yml
@@ -1,96 +1,96 @@
 general:
-  must_be_player: <negative>Nur Spieler können diesen Befehl verwenden.
-  no_perm: <negative>Dir fehlt die notwendige Berechtigung.
+  must_be_player: <prefix_negative>Nur Spieler können diesen Befehl verwenden.
+  no_perm: <prefix_negative>Dir fehlt die notwendige Berechtigung.
   cmd:
-    no_perm: <negative>Du hast keine Berechtigung für diesen Befehl.
-  player_not_found: '<negative>Spieler nicht gefunden: <name>'
+    no_perm: <prefix_negative>Du hast keine Berechtigung für diesen Befehl.
+  player_not_found: '<prefix_negative>Spieler nicht gefunden: {name}'
 ritual:
-  failure: <positive><ritual> war erfolgreich! Du seist gesegnet!
-  success: <negative><ritual> ist gescheitert - Bedingungen nicht erfüllt!
-  start: <light_purple>The <ritual> hat begonnen...
+  failure: <prefix>{ritual} war erfolgreich! Du seist gesegnet!
+  success: <prefix_negative>{ritual} ist gescheitert - Bedingungen nicht erfüllt!
+  start: <light_purple>The {ritual} hat begonnen...
   return_to_resume: <light_purple>Kehre zum Schrein zurück um das Ritual zu beenden.
   cmd:
     specify_ritual: <yellow>Gebe ein Ritual an, um Information dazu zu erhalten.
-    usage: '<warning>Verwendung: /ritual <info> [RitualName]'
-  not_found: <negative>Unbekanntes Ritual. Bitte wähle einen gültigen Namen.
+    usage: '<prefix_warning>Verwendung: <cmd_syntax>/ritual <arg>info</arg> <arg_opt>RitualName</arg_opt></cmd_syntax>'
+  not_found: <prefix_negative>Unbekanntes Ritual. Bitte wähle einen gültigen Namen.
   info: |-
-    <gold>Details zu <display-name>
-    <yellow>Beschreibung: <gray><description>
-    <yellow>Schlüssel Item: <gray><item-name>
-    <yellow>Gunst ausgezahlt: <gray><favour-amount>
+    <gold>Details zu {display-name}
+    <yellow>Beschreibung: <gray>{description}
+    <yellow>Schlüssel Item: <gray>{item-name}
+    <yellow>Gunst ausgezahlt: <gray>{favour-amount}
 favor:
   cmd:
-    usage: '<warning>Usage: /favor <set|give|take> <playername> <amount>'
-    player_does_not_worship: <negative><player> verehrt keine Gottheit.
-    invalid_number_format: <negative>Ungültige Anzahl. Bitte gib eine Ganzzahl an.
-    invalid_action: <negative>Ungültige Aktion. Verwende set, give, oder take.
-  current_favor: 'Deine aktuelle Gunst beträgt: <favor>'
-  no_devotion_set: <negative>Du hast keine Ergebenheit gesetzt.
+    usage: '<prefix_warning>Usage: <cmd_syntax>/favor set|give|take <arg>playername</arg> <arg>amount</arg></cmd_syntax>'
+    player_does_not_worship: <prefix_negative><player> verehrt keine Gottheit.
+    invalid_number_format: <prefix_negative>Ungültige Anzahl. Bitte gib eine Ganzzahl an.
+    invalid_action: <prefix_negative>Ungültige Aktion. Verwende set, give, oder take.
+  current_favor: '<prefix>Deine aktuelle Gunst bei {deity} beträgt: <favor_col>{favor}'
+  no_devotion_set: <prefix_negative>Du hast keine Ergebenheit gesetzt.
 meditation:
-  cancelled: <negative>Du hast dich beim Meditieren bewegt! Starte Timer neu...
-  complete: <positive>Meditation abgeschlossen! Du kannst dich nun bewegen.
+  cancelled: <prefix_negative>Du hast dich beim Meditieren bewegt! Starte Timer neu...
+  complete: <prefix>Meditation abgeschlossen! Du kannst dich nun bewegen.
 devotion:
-  set: <positive>Du bist nun <deity> ergeben. Deine Gunst beträgt <favor>.
-  reload_success: <positive>Devotions erfolgreich neu geladen!
+  set: <prefix>Du bist nun {deity} ergeben. Deine Gunst beträgt <favor_col>{favor}.
+  reload_success: <prefix>Devotions erfolgreich neu geladen!
 miracle:
-  repair: <positive>Ein Wunder hat all deine Items repariert!
-  iron_golem: <positive>Ein Wunder hat Eisengolems beschworen, um dich zu beschützen!
-  harvest: <positive>Ein Wunder segnet dich mit reicher Ernte!
-  hero_of_the_village: <positive>Ein Wunder macht dich zum Held des Dorfes!
-  bestowed: <positive>Dir wurde ein Wunder beschert!
-  fire_resistance: <positive>Ein Wunder schützt dich vor Verbrennungen!
+  repair: <prefix>Ein Wunder hat all deine Items repariert!
+  iron_golem: <prefix>Ein Wunder hat Eisengolems beschworen, um dich zu beschützen!
+  harvest: <prefix>Ein Wunder segnet dich mit reicher Ernte!
+  hero_of_the_village: <prefix>Ein Wunder macht dich zum Held des Dorfes!
+  bestowed: <prefix>Dir wurde ein Wunder beschert!
+  fire_resistance: <prefix>Ein Wunder schützt dich vor Verbrennungen!
   cmd:
-    unknown_miracle: '<negative>Unbekanntes Wunder: <miracle>'
-    applied: '<positive>Wunder angewandt: <yellow><miracle>'
-    usage: '"<warning>Verwendung: /testmiracle <miracleName>"'
-    no_miracles: <negative>Es wurden keine Wunder geladen.
-  saved_from_death: <positive>Ein Wunder hat dich vor dem Tod bewahrt!
-  wolves: <positive>Ein Wunder beschwört freundliche Wölfe, um dich zu beschützen!
+    unknown_miracle: '<prefix_negative>Unbekanntes Wunder: {miracle}'
+    applied: '<prefix>Wunder angewandt: <yellow>{miracle}'
+    usage: '"<prefix_warning>Verwendung: <cmd_syntax>/testmiracle <arg>miracleName</arg></cmd_syntax>"'
+    no_miracles: <prefix_negative>Es wurden keine Wunder geladen.
+  saved_from_death: <prefix>Ein Wunder hat dich vor dem Tod bewahrt!
+  wolves: <prefix>Ein Wunder beschwört freundliche Wölfe, um dich zu beschützen!
 shrines:
   set:
-    no_perm: <negative>Du hast keine Berechtigung, um Schreine zu setzen.
-  follow_deity_to_designate: <negative>Du musst einer Gottheit folgen, um einen Schrein zu bestimmen!
-  click_block_to_create: <warning>Rechtsklicke einen Block, um ein Heiligtum für <deity> zu bestimmen!
-  cannot_place_on_top: <negative>Du kannst keine Blöcke auf einen Schrein platzieren
+    no_perm: <prefix_negative>Du hast keine Berechtigung, um Schreine zu setzen.
+  follow_deity_to_designate: <prefix_negative>Du musst einer Gottheit folgen, um einen Schrein zu bestimmen!
+  click_block_to_create: <prefix_warning>Rechtsklicke einen Block, um ein Heiligtum für {deity} zu bestimmen!
+  cannot_place_on_top: <prefix_negative>Du kannst keine Blöcke auf einen Schrein platzieren
   list:
-    no_shrines: <negative>Es gibt keine Schreine.
-    no_perm: <negative>Du hast keine Berechtigung, um Schreine aufzulisten.
+    no_shrines: <prefix_negative>Es gibt keine Schreine.
+    no_perm: <prefix_negative>Du hast keine Berechtigung, um Schreine aufzulisten.
     header: '<yellow>Schreine:'
-    shrine: <hover:show_text:Click to teleport><click:run_cmd:/teleport <x> <y>
-      <z>><deity> bei <x:#.#>, <y:#.#>, <z:#.#>
-  offering_accepted: <positive>Dein Opfer wurde akzeptiert!
+    shrine: <hover:show_text:Click to teleport><click:run_command:'/teleport {x} {y}
+      {z}'>{deity} bei {x:#.#}, {y:#.#}, {z:#.#}
+  offering_accepted: <prefix>Dein Opfer wurde akzeptiert!
   remove:
-    success: <positive>Schrein erfolgreich entfernt!
-    no_perm: <negative>Du hast keine Berechtigung, um Schreine zu entfernen.
-    not_found: <negative>Kein Schrein an der Position gefunden.
-  right_click_to_remove: <warning>Rechtsklicke einen Schrein, um ihn zu entfernen.
-  deity_not_found: <negative>Konnte deine Gottheit nicht ermitteln, kontaktiere einen Administrator.
-  limit_reached: <negative>Du hast dein Limit für Schreine erreicht (<limit>).
-  cannot_break_shrines: <negative>Du kannst Schreine nicht abbauen. Entferne sie mit <warning>/shrine
-    remove</warning>.
-  cooldown: <negative>Du musst weitere <cooldown:'m'> Minuten und <cooldown:'s'> warten, um ein weiteres Ritual auszuführen.
-  offering_declined: <negative>Dein Opfer wurde von <subject> nicht akzeptiert.
-  not_following_deity: <negative>Nur Anhänger von <deity> können diesen Schrein anbeten.
-  shrine_created: <positive>Erfolgreich einen Schrein für <deity> bestimmt!
+    success: <prefix>Schrein erfolgreich entfernt!
+    no_perm: <prefix_negative>Du hast keine Berechtigung, um Schreine zu entfernen.
+    not_found: <prefix_negative>Kein Schrein an der Position gefunden.
+  right_click_to_remove: <prefix_warning>Rechtsklicke einen Schrein, um ihn zu entfernen.
+  deity_not_found: <prefix_negative>Konnte deine Gottheit nicht ermitteln, kontaktiere einen Administrator.
+  limit_reached: <prefix_negative>Du hast dein Limit für Schreine erreicht ({limit}).
+  cannot_break_shrines: <prefix_negative>Du kannst Schreine nicht abbauen. Entferne sie mit <cmd_syntax>/shrine
+    remove</cmd_syntax>.
+  cooldown: "<prefix_negative>Du musst {cooldown:'m'}m und {cooldown:'s'}s warten, um ein weiteres Ritual auszuführen."
+  offering_declined: <prefix_negative>Dein Opfer wurde von {subject} nicht akzeptiert.
+  not_following_deity: <prefix_negative>Nur Anhänger von {deity} können diesen Schrein anbeten.
+  shrine_created: <prefix>Erfolgreich einen Schrein für {deity} bestimmt!
 deity:
-  no_deity_found: <negative>Keine Gottheiten gefunden.
-  cursed: <positive><deity> verflucht dich mit <curse>!
-  blessed: <positive><deity> segnet dich mit <blessing>!
+  no_deity_found: <prefix_negative>Keine Gottheiten gefunden.
+  cursed: <prefix>{deity} verflucht dich mit {curse}!
+  blessed: <prefix>{deity} segnet dich mit {blessing}!
   cmd:
     specify_deity: <yellow>Bitte gebe eine Gottheit an, der du folgen möchtest.
-    specify_player: <warning>Bitte gebe eine Gottheit an, um Informationen zu ihr zu erhalten.
-    usage: '<warning>Verwendung: /Verwendung <select|info> [Gottheit]'
+    specify_player: <prefix_warning>Bitte gebe eine Gottheit an, um Informationen zu ihr zu erhalten.
+    usage: '<prefix_warning>Verwendung: <cmd_syntax>/Verwendung <arg>select|info</arg> <arg_opt>Gottheit</arg_opt></cmd_syntax>'
   list:
-    entry: <gray>- <name></gray>
+    entry: <gray>- {name}</gray>
     header: '<gold>Mögliche Gottheiten:'
-  not_found: <negative>Unbekannte Gottheit, bitte gebe einen gültigen Namen an.
+  not_found: <prefix_negative>Unbekannte Gottheit, bitte gebe einen gültigen Namen an.
   info: |-
-    <gold>Details zu <name>
-    <yellow>Beschreibung: <gray><lore>
-    <yellow>Domain: <gray><domain>
-    <yellow>Alignment: <gray><alignment>
-    <yellow>Favored Rituals: <gray><rituals>
-    <yellow>Favored Offerings: <gray><offerings>
+    <gold>Details zu {name}
+    <yellow>Beschreibung: <gray>{lore}
+    <yellow>Domain: <gray>{domain}
+    <yellow>Alignment: <gray>{alignment}
+    <yellow>Favored Rituals: <gray>{rituals}
+    <yellow>Favored Offerings: <gray>{offerings}
 miracles:
   cmd:
-    list_available: '<positive>Verfügbare Wunder: <yellow><miracles>'
+    list_available: '<prefix>Verfügbare Wunder: <yellow>{miracles}'

--- a/src/main/resources/lang/styles.yml
+++ b/src/main/resources/lang/styles.yml
@@ -1,0 +1,10 @@
+# Remove devotion styling rules to apply global styles instead.
+primary: <gold>{slot}</gold>
+offset: <yellow>{slot}</yellow>
+accent: <light_purple>{slot}</light_purple>
+
+prefix: <positive>{slot}</positive>
+prefix_negative: <negative>{slot}</negative>
+prefix_warning: <warning>{slot}</warning>
+text: <gray>{slot}</gray>
+cmd_syntax: <warning>{slot}</warning>


### PR DESCRIPTION
Applies the most recommended tags in the translations file and changes placeholder tags from `<selfclosing/>` to `{placeholder}`.
The chat will look the same but by clearing the styles.yml style sheet you can apply the serverwise global styles.